### PR TITLE
patch#001

### DIFF
--- a/zbxtg.sh
+++ b/zbxtg.sh
@@ -51,7 +51,6 @@ ${TG_TEXT}" 2>/dev/null
     ;;
 
     "image")
-        PERIOD=3600 # default period
         echo "${BODY}" | grep -q "^${ZBX_TG_PREFIX};graphs_period" && PERIOD=$(echo "${BODY}" | awk -F '=' /graphs_period/'{print $NF}')  || PERIOD=3600
         ZBX_ITEMID=$(echo "${BODY}" | awk -F ':' /itemid/'{print $NF}')
         ZBX_TITLE=$(echo "${BODY}" | awk -F ':' /title/'{print $NF}')

--- a/zbxtg.sh
+++ b/zbxtg.sh
@@ -51,7 +51,7 @@ ${TG_TEXT}" 2>/dev/null
     ;;
 
     "image")
-        echo "${BODY}" | grep -q "^${ZBX_TG_PREFIX};graphs_period" && PERIOD=$(echo "${BODY}" | awk -F '=' /graphs_period/'{print $NF}')  || PERIOD=3600
+        PERIOD=$(echo "${BODY}" | awk -F '=' /graphs_period/'{print $NF}') && [ -z $PERIOD ] && PERIOD=3600
         ZBX_ITEMID=$(echo "${BODY}" | awk -F ':' /itemid/'{print $NF}')
         ZBX_TITLE=$(echo "${BODY}" | awk -F ':' /title/'{print $NF}')
         URL="${ZBX_SERVER}/chart3.php?period=${PERIOD}&name=${ZBX_TITLE}&width=900&height=200&graphtype=0&legend=1&items[0][itemid]=${ZBX_ITEMID}&items[0][sortorder]=0&items[0][drawtype]=5&items[0][color]=00CC00"


### PR DESCRIPTION
34 to 41: The source type (chat or private) does not matter anymore. The value is retrieved in both types.
46 to 52: The way to get the chat_id has been simplified, and the uids.txt file, no longer chat or private value.
66 to 68: Simplified the code to set the value of the variable.

Unfortunately I could not perform all the tests that you would like to validate the changes, but the tests I conducted in my laboratory, worked well.
I hope it works for you too. :)