### PR TITLE
Add emoji replacement case insensitive

### DIFF
--- a/zbxtg.py
+++ b/zbxtg.py
@@ -411,7 +411,7 @@ def main():
         for l in zbxtg_body_text:
             l_new = l
             for k, v in zbxtg_settings.emoji_map.iteritems():
-                l_new = l_new.replace("{{" + k + "}}", v)
+                l_new = re.sub("{{" + k + "}}", v, l_new, flags=re.IGNORECASE)
             zbxtg_body_text_emoji_support.append(l_new)
         zbxtg_body_text = zbxtg_body_text_emoji_support
 


### PR DESCRIPTION
Recently we find a problem with how our actions where declared. Some Subjects have the {{OK}} in capital letters, others like {{Ok}} and the emoji substitution didn't work.

With this patch any combination makes the substitution works.