### PR TITLE
Use /var/tmp instead of /tmp as default

### DIFF
--- a/zbxtg_settings.example.py
+++ b/zbxtg_settings.example.py
@@ -3,7 +3,7 @@
 tg_key = "XYZ"  # telegram bot api key
 
 zbx_tg_prefix = "zbxtg"  # variable for separating text from script info
-zbx_tg_tmp_dir = "/tmp/" + zbx_tg_prefix  # directory for saving caches, uids, cookies, etc.
+zbx_tg_tmp_dir = "/var/tmp/" + zbx_tg_prefix  # directory for saving caches, uids, cookies, etc.
 zbx_tg_signature = False
 
 zbx_server = "http://localhost"  # zabbix server full url


### PR DESCRIPTION
Any reason not to?
It's writable by everyone the same way as `/tmp`, but not being erased between OS reboots.