### PR TITLE
Bugfix in zbxtg.py

### DIFF
--- a/zbxtg.py
+++ b/zbxtg.py
@@ -109,6 +109,8 @@ class TelegramAPI():
                 chat = m["message"]["chat"]
             elif "edited_message" in m:
                 chat = m["edited_message"]["chat"]
+            else:
+                continue
             if chat["type"] == self.type == "private":
                 if "username" in chat:
                     if chat["username"] == name:


### PR DESCRIPTION
Traceback (most recent call last):
  File "./zbxtg.py", line 458, in <module>
    main()
  File "./zbxtg.py", line 387, in main
    uid = tg.get_uid(zbx_to)
  File "./zbxtg.py", line 112, in get_uid
    if chat["type"] == self.type == "private":
UnboundLocalError: local variable 'chat' referenced before assignment