### PR TITLE
fix #107 need to send some text bot in private

### DIFF
--- a/zbxtg.py
+++ b/zbxtg.py
@@ -182,6 +182,9 @@ class TelegramAPI:
                 if "username" in chat:
                     if chat["username"] == name:
                         uid = chat["id"]
+                else:
+                    if chat["first_name"] + " " + chat["last_name"] == name:                         
+                        uid = chat["id"]
             if (chat["type"] == "group" or chat["type"] == "supergroup") and self.type == "group":
                 if "title" in chat:
                     if chat["title"] == name.decode("utf-8"):


### PR DESCRIPTION
if a user has no username in telegram the python script will get no uid and can not send messages to a telegram bot.

I have added a check when no username was found, so it checks the first and lastname and then get the chat["id"]

Tested with Zabbix 3.4 and python 2.7.13 / 3.5.3