### PR TITLE
Group id fix

### DIFF
--- a/zbxtg.py
+++ b/zbxtg.py
@@ -174,6 +174,8 @@ class TelegramAPI:
 
     def get_uid(self, name):
         uid = 0
+        if sys.version_info[0] < 3:
+            name = name.decode("utf-8")
         if self.debug:
             print_message("Getting uid from /getUpdates...")
         updates = self.get_updates()
@@ -190,12 +192,9 @@ class TelegramAPI:
                         uid = chat["id"]
             if (chat["type"] == "group" or chat["type"] == "supergroup") and self.type == "group":
                 if "title" in chat:
-                    if sys.version_info[0] < 3:
-                        if chat["title"] == name.decode("utf-8"):
-                            uid = chat["id"]
-                    else:
-                        if chat["title"] == name:
-                            uid = chat["id"]
+                    if chat["title"] == name:
+                        uid = chat["id"]
+                        break
         if self.debug:
             print_message("Use uid = {0}".format(uid))
         return uid

--- a/zbxtg.py
+++ b/zbxtg.py
@@ -190,9 +190,11 @@ class TelegramAPI:
                 if "username" in chat:
                     if chat["username"] == name:
                         uid = chat["id"]
+                        break
             if (chat["type"] == "group" or chat["type"] == "supergroup") and self.type == "group":
                 if name == str(chat["id"]).encode("utf-8").decode("utf-8"):
                     uid = name
+                    break
                 if "title" in chat:
                     if chat["title"] == name:
                         uid = chat["id"]

--- a/zbxtg.py
+++ b/zbxtg.py
@@ -196,6 +196,8 @@ class TelegramAPI:
                     else:
                         if chat["title"] == name:
                             uid = chat["id"]
+        if self.debug:
+            print_message("Use uid = {0}".format(uid))
         return uid
 
     def error_need_to_contact(self, to):

--- a/zbxtg.py
+++ b/zbxtg.py
@@ -191,6 +191,8 @@ class TelegramAPI:
                     if chat["username"] == name:
                         uid = chat["id"]
             if (chat["type"] == "group" or chat["type"] == "supergroup") and self.type == "group":
+                if name == str(chat["id"]).encode("utf-8").decode("utf-8"):
+                    uid = name
                 if "title" in chat:
                     if chat["title"] == name:
                         uid = chat["id"]


### PR DESCRIPTION
I added functionality to use chat.id for group chats, message by chat.title still works.