### PR TITLE
Update versions of PySocks & requests-oauthlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PySocks==1.6.8
+PySocks==1.7.0
 requests==2.20.0
-requests-oauthlib==0.6.2
+requests-oauthlib==1.2.0


### PR DESCRIPTION
Updated versions of these packages also work as well.

Although installing `requests==2.20.0` from pip breaks the system on CentOS 7.
I've faced this on installing certbot, as it installs `python-urllib3==1.10.2` and latest version of `urllib3` in pip packages is `urllib3==1.25.4`, it cannot remove the `python-urllib3` package installed by CentOS, therefore requests break too.

I should've uninstall `urllib3` and `requests` installed by pip using `pip uninstall urllib3 requests` and install `python-urllib3==1.10.2` and `python-requests==2.6.0` package from CentOS repo again.