### PR TITLE
Added randomizer of file name in graph_get()

### DIFF
--- a/zbxtg.py
+++ b/zbxtg.py
@@ -304,7 +304,8 @@ class ZabbixWeb:
         self.cookie = cookie
 
     def graph_get(self, itemid, period, title, width, height, version=3):
-        file_img = self.tmp_dir + "/{0}.png".format("".join(itemid))
+        file_img = "{0}/{1}.png".format(self.tmp_dir,                                                   
+                                        "".join(random.choice(string.ascii_letters) for e in range(10)))
 
         title = requests.utils.quote(title)
 


### PR DESCRIPTION
Our monitoring guys contacted me with issue: when zabbix runs `zbxtg` too fast some of images can double each other and other artifacts. Suggested solution was tested, I think 'period' is not enough for cases when one file maybe hijacked by another script instance.